### PR TITLE
Convert cicd-test/cicd-test-ASP.NET_Core-CI_(1) to GitHub Actions

### DIFF
--- a/.github/workflows/cicd-test-asp.net_core-ci_(1).yml
+++ b/.github/workflows/cicd-test-asp.net_core-ci_(1).yml
@@ -1,0 +1,40 @@
+name: cicd-test/cicd-test-ASP.NET_Core-CI_(1)
+on:
+  workflow_dispatch:
+env:
+  BuildConfiguration: Release
+  BuildPlatform: any cpu
+  Parameters_RestoreBuildProjects: "**/*.csproj"
+  Parameters_TestProjects: "**/*[Tt]ests/*.csproj"
+  system_debug: 'false'
+jobs:
+  Job_1:
+    name: Agent job 1
+    runs-on:
+      - self-hosted
+      - Default
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: Restore
+      run: |-
+        dotnet nuget add source "https://pkgs.dev.azure.com/mrnyeinchan55/_packaging/8923ca26-2122-4108-b673-bea14fc324e8/nuget/v3/index.json" --name "8923ca26-2122-4108-b673-bea14fc324e8" --username "n/a" --password "${{ secrets.AZURE_DEVOPS_TOKEN }}" --store-password-in-clear-text
+        dotnet restore ${{ env.Parameters_RestoreBuildProjects }} --verbosity "Detailed"
+    - name: Build
+      run: dotnet build ${{ env.Parameters_RestoreBuildProjects }} --configuration ${{ env.BuildConfiguration }}
+    - name: Test
+      run: dotnet test ${{ env.Parameters_TestProjects }} --logger trx --results-directory "${{ runner.temp }}" --configuration ${{ env.BuildConfiguration }}
+    - name: Test
+      uses: NasAmin/trx-parser@v0.5.0
+      if: always()
+      with:
+        TRX_PATH: "${{ runner.temp }}"
+        REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Publish
+      run: dotnet publish ${{ env.Parameters_RestoreBuildProjects }} --configuration ${{ env.BuildConfiguration }} --output ${{ runner.temp }}
+    - name: Publish Artifact
+      if: success() || failure()
+      uses: actions/upload-artifact@v4.1.0
+      with:
+        name: drop
+        path: "\\\\my\\share\\${{ github.workflow }}\\${{ github.run_number }}"


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/mrnyeinchan55/cicd-test/_build?definitionId=14) :tada:

## Manual steps

Perform the following steps to complete the migration:

### cicd-test/cicd-test-ASP.NET Core-CI (1)
- [x] Ensure a runner with the following labels exists: Default
- [x] Ensure secret is available: `${{ secrets.AZURE_DEVOPS_TOKEN }}`